### PR TITLE
Please use kDebug() instead of qDebug()

### DIFF
--- a/App/main.cpp
+++ b/App/main.cpp
@@ -25,7 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "touchecore.h"
 #include "domain/deviceinfo.h"
 #include <kaction.h>
-#include <QDebug>
+#include <KDebug>
 #include <kaboutdata.h>
 #include <kcmdlineargs.h>
 #include <QtCore/QTimer>

--- a/Core/backend/config/bindingsconfig.cpp
+++ b/Core/backend/config/bindingsconfig.cpp
@@ -25,7 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QMap>
 #include <QSettings>
 #include <QCoreApplication>
-#include <QDebug>
+#include <KDebug>
 #include <functional>
 
 #define BINDING_DO_NOTHING "DoNothing"

--- a/Core/backend/config/databaseentry.cpp
+++ b/Core/backend/config/databaseentry.cpp
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "domain/configevent.h"
 #include "domain/nomoreeventsinputevent.h"
 #include <QList>
-#include <QDebug>
+#include <KDebug>
 
 class DatabaseEntryPrivate {
 public:

--- a/Core/backend/config/keyboarddatabase.cpp
+++ b/Core/backend/config/keyboarddatabase.cpp
@@ -21,7 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <qjson/parser.h>
 #include <QFile>
 #include <QVariantMap>
-#include <QDebug>
+#include <KDebug>
 #include "domain/deviceinfo.h"
 #include "domain/inputevent.h"
 #include "databaseentry.h"
@@ -58,7 +58,7 @@ KeyboardDatabase::KeyboardDatabase(QStringList databaseFiles, QObject *parent) :
 {
     Q_D(KeyboardDatabase);
     d->emptyDatabaseEntry.setProperty("deviceName", "Device not configured");
-    qDebug() << "Using keyboard database paths: " << databaseFiles;
+    kDebug() << "Using keyboard database paths: " << databaseFiles;
 }
 
 KeyboardDatabase::~KeyboardDatabase()

--- a/Core/backend/hiddev/finddevices.cpp
+++ b/Core/backend/hiddev/finddevices.cpp
@@ -22,7 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QMap>
 #include "backend/hiddev/hiddev.h"
 #include <QDir>
-#include <QDebug>
+#include <KDebug>
 #include "domain/deviceinfo.h"
 #include <QtCore/QTimer>
 #include <QThread>
@@ -62,7 +62,7 @@ public:
     void addDevice(const QString &devicePath) {
         Q_Q(FindDevices);
         if(devices.contains(devicePath)) return;
-        qDebug() << "Adding device: " << devicePath;
+        kDebug() << "Adding device: " << devicePath;
         QThread *deviceThread = new QThread(q);
         HidDev *device = new HidDev(devicePath, keyboardDatabase);
         deviceThread->start();
@@ -92,22 +92,22 @@ FindDevices::~FindDevices()
 
 void FindDevices::deviceRemoved(DeviceInfo *deviceInfo)
 {
-    qDebug() << "device removed: " << deviceInfo->name();
+    kDebug() << "device removed: " << deviceInfo->name();
     Q_D(FindDevices);
     DevicePair device = d->devices.take(deviceInfo->path());
     emit disconnected(deviceInfo);
     delete device.second;
     device.first->quit();
     device.first->wait();
-    qDebug() << "cleaning up on FindDevices";
+    kDebug() << "cleaning up on FindDevices";
     delete device.first;
-    qDebug() << "Devices list is now " << d->devices;
+    kDebug() << "Devices list is now " << d->devices;
 }
 
 void FindDevices::deviceChanged()
 {
     Q_D(FindDevices);
-    qDebug() << "Device list changed";
+    kDebug() << "Device list changed";
     d->scanDevices();
 }
 

--- a/Core/backend/hiddev/hid_inputevent.cpp
+++ b/Core/backend/hiddev/hid_inputevent.cpp
@@ -19,7 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "hid_inputevent.h"
 #include <QMultiMap>
-#include <QDebug>
+#include <KDebug>
 #include <QStringList>
 #include <QPair>
 
@@ -38,7 +38,7 @@ public:
             if(!this->registers.values(hid).contains(value))
                 return false;
         }
-        qDebug() << "Match for version " << versionName;
+        kDebug() << "Match for version " << versionName;
         return true;
     }
 

--- a/Core/backend/hiddev/hiddev.cpp
+++ b/Core/backend/hiddev/hiddev.cpp
@@ -35,7 +35,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QMutexLocker>
 #include <QElapsedTimer>
 
-#include <QDebug>
+#include <KDebug>
 #include "backend/config/databaseentry.h"
 #include "domain/deviceinfo.h"
 #include "backend/config/keyboarddatabase.h"
@@ -85,7 +85,7 @@ public:
         FD_SET(fd, &(fdset));
         int selectRD = select(fd+1, &(fdset), NULL, NULL, &tv);
         if(selectRD==-1) {
-            qDebug() << "Error on select: " << strerror(errno);
+            kDebug() << "Error on select: " << strerror(errno);
             stop();
             return;
         }
@@ -102,7 +102,7 @@ public:
         int rd = read(fd, ev, sizeof(ev));
         if(rd==-1) {
             stop();
-            qDebug() << "Error on read: " << strerror(errno);
+            kDebug() << "Error on read: " << strerror(errno);
             return;
         }
         HidInputEvent *keyEvent = new HidInputEvent(q);
@@ -142,13 +142,13 @@ void HidDev::start()
     while(d->fd==-1) {
         d->fd = open(d->deviceInfo.path().toLatin1(), O_RDONLY);
         if(d->fd==-1 && d->errors_timer.elapsed() > OPEN_TIMEOUT) {
-            qDebug() << "Error on open: " << strerror(errno) << " for more than " << OPEN_TIMEOUT << " milliseconds; giving up.";
+            kDebug() << "Error on open: " << strerror(errno) << " for more than " << OPEN_TIMEOUT << " milliseconds; giving up.";
             // TODO: emit signal for gui notification
             return;
         }
         qApp->processEvents();
     }
-    qDebug() << "Hid dev opened: " << d->fd;
+    kDebug() << "Hid dev opened: " << d->fd;
 
 
     int version;
@@ -158,7 +158,7 @@ void HidDev::start()
     err << QString("hiddev driver version is %1.%2.%3\n").arg(version >> 16).arg((version >> 8) & 0xff).arg(version & 0xff);
 
     ioctl(d->fd, HIDIOCGDEVINFO, &dinfo);
-    qDebug() << "Product: " << QString("%1").arg((quint16) dinfo.product, 4, 16, QChar('0'));
+    kDebug() << "Product: " << QString("%1").arg((quint16) dinfo.product, 4, 16, QChar('0'));
     d->deviceInfo.vendor(dinfo.vendor)->productID(dinfo.product)->version(dinfo.version)
             ->bus(dinfo.busnum)->deviceNumber(dinfo.devnum)->interfaceNumber(dinfo.ifnum);
     err << QString("HID: vendor 0x%1 product 0x%2 version 0x%3\n")
@@ -179,20 +179,20 @@ void HidDev::start()
     d->deviceInfo.name(keyboardDatabaseEntry.value("name").toString());
     d->deviceInfo.keyboardDatabaseEntry(keyboardDatabaseEntry);
 
-    qDebug() << "Read timeout set to " << d->read_timeout_milliseconds << " milliseconds";
+    kDebug() << "Read timeout set to " << d->read_timeout_milliseconds << " milliseconds";
     emit connected(&d->deviceInfo);
     while(d->fd!=-1 && !d->aboutToQuit) {
         qApp->processEvents();
         d->read_events();
     }
-    qDebug() << "Device loop stopped";
+    kDebug() << "Device loop stopped";
     emit removed(&d->deviceInfo);
 }
 
 void HidDev::stop()
 {
     Q_D(HidDev);
-    qDebug() << "qapp said it's time to go...";
+    kDebug() << "qapp said it's time to go...";
     QMutexLocker locker(&d->mutex);
     Q_UNUSED(locker);
     d->stop();

--- a/Core/backend/updatekeysymbolmapping.cpp
+++ b/Core/backend/updatekeysymbolmapping.cpp
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ***********************************************************************/
 
 #include "updatekeysymbolmapping.h"
-#include <QDebug>
+#include <KDebug>
 #include <X11/XKBlib.h>
 #include <QX11Info>
 #include <QFile>

--- a/Core/domain/configevent.cpp
+++ b/Core/domain/configevent.cpp
@@ -22,7 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QMap>
 #include <QVariant>
 #include <QStringList>
-#include <QDebug>
+#include <KDebug>
 #include "backend/config/bindingsconfig.h"
 #include "domain/binding.h"
 
@@ -51,7 +51,7 @@ Binding *ConfigEvent::matches(InputEvent *other, const QStringList &tags, Bindin
             QString eventName = QString("%1/%2")
                     .arg(property("keyName").toString() )
                     .arg(tag);
-            qDebug() << "Got match: " << eventName;
+            kDebug() << "Got match: " << eventName;
             return bindingsConfig->bindingFor(eventName, other->nearestQObject());
         }
     }

--- a/Core/domain/donothingbinding.cpp
+++ b/Core/domain/donothingbinding.cpp
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ***********************************************************************/
 
 #include "donothingbinding.h"
-#include <QDebug>
+#include <KDebug>
 
 DoNothingBinding::DoNothingBinding(QObject *parent) :
     QObject(parent)
@@ -31,5 +31,5 @@ DoNothingBinding::~DoNothingBinding()
 
 void DoNothingBinding::execute()
 {
-    qDebug() << "Executing \"DoNothingBinding\"";
+    kDebug() << "Executing \"DoNothingBinding\"";
 }

--- a/Core/domain/nomoreeventsinputevent.cpp
+++ b/Core/domain/nomoreeventsinputevent.cpp
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ***********************************************************************/
 
 #include "nomoreeventsinputevent.h"
-#include <QDebug>
+#include <KDebug>
 
 NoMoreEventsInputEvent::NoMoreEventsInputEvent(QObject *parent) :
     QObject(parent)

--- a/Core/domain/runcommandbinding.cpp
+++ b/Core/domain/runcommandbinding.cpp
@@ -19,7 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "runcommandbinding.h"
 #include <QProcess>
-#include <QDebug>
+#include <KDebug>
 
 class RunCommandBindingPrivate {
 public:
@@ -41,7 +41,7 @@ RunCommandBinding::~RunCommandBinding()
 void RunCommandBinding::execute()
 {
     Q_D(RunCommandBinding);
-    qDebug() << "executing \"RunCommandBinding\": command `" << d->command << "` with arguments [" << d->arguments.join(" ") << "]";
+    kDebug() << "executing \"RunCommandBinding\": command `" << d->command << "` with arguments [" << d->arguments.join(" ") << "]";
     QProcess::startDetached(d->command, d->arguments);
 }
 

--- a/Core/domain/tokeybinding.cpp
+++ b/Core/domain/tokeybinding.cpp
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ***********************************************************************/
 
 #include "tokeybinding.h"
-#include <QDebug>
+#include <KDebug>
 #include <X11/extensions/XTest.h>
 #include <X11/Xlib.h>
 #include <QX11Info>
@@ -68,6 +68,6 @@ void ToKeyBinding::execute()
         }
         return;
     }
-    qDebug() << QString("executing \"ToKeyBinding\": sending key%1  with keysym: \"%2\" [0x%3]; keycode:  %4").arg(d->isKeypress ? "press" : "release").arg(d->keySymName).arg(keysym, 0,16).arg(keycode);
+    kDebug() << QString("executing \"ToKeyBinding\": sending key%1  with keysym: \"%2\" [0x%3]; keycode:  %4").arg(d->isKeypress ? "press" : "release").arg(d->keySymName).arg(keysym, 0,16).arg(keycode);
     XTestFakeKeyEvent(QX11Info::display(), keycode, d->isKeypress, 0 );
 }

--- a/Core/domain/translatekeyevents.cpp
+++ b/Core/domain/translatekeyevents.cpp
@@ -19,7 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "translatekeyevents.h"
 #include "domain/inputevent.h"
-#include <QDebug>
+#include <KDebug>
 #include <QMap>
 #include "domain/binding.h"
 #include "domain/runcommandbinding.h"

--- a/Core/touchecore.cpp
+++ b/Core/touchecore.cpp
@@ -26,7 +26,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "backend/config/keyboarddatabase.h"
 #include "backend/config/bindingsconfig.h"
 #include <QCoreApplication>
-#include <QDebug>
+#include <KDebug>
 #include <QtCore/QTimer>
 #include <QProcessEnvironment>
 
@@ -48,7 +48,7 @@ public:
 class __RegisterMetatypes__ {
 public:
     __RegisterMetatypes__() {
-        qDebug() << "Registering InputEventP";
+        kDebug() << "Registering InputEventP";
         qRegisterMetaType<InputEventP>();
     }
 };

--- a/GUI/touchesystemtray.cpp
+++ b/GUI/touchesystemtray.cpp
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ***********************************************************************/
 
-#include <QDebug>
+#include <KDebug>
 #include "touchesystemtray.h"
 #include <QMenu>
 #include <QCoreApplication>
@@ -96,7 +96,7 @@ void ToucheSystemTray::deviceConnected(DeviceInfo *deviceInfo)
 void ToucheSystemTray::deviceDisconnected(DeviceInfo *deviceInfo)
 {
     Q_D(ToucheSystemTray);
-    qDebug() << "about to quit: " << d->aboutToQuit;
+    kDebug() << "about to quit: " << d->aboutToQuit;
     if(d->aboutToQuit)
         return;
     QString messageTitle = QString("<b>%1</b>: %2").arg(qAppName()).arg(i18nc("device disconnected tray popup", "Device Disconnected!"));

--- a/Settings/bindingconfigurationwidget.cpp
+++ b/Settings/bindingconfigurationwidget.cpp
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ***********************************************************************/
 
 #include "bindingconfigurationwidget.h"
-#include <QDebug>
+#include <KDebug>
 #include <QSettings>
 #include "models/cfgkeyevent.h"
 

--- a/Settings/bindingsGui/x11keysymbolscompleter.cpp
+++ b/Settings/bindingsGui/x11keysymbolscompleter.cpp
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ***********************************************************************/
 
 #include "x11keysymbolscompleter.h"
-#include <QDebug>
+#include <KDebug>
 
 class X11KeySymbolsCompleterPrivate {
 public:

--- a/Settings/keybindingconfiguration.cpp
+++ b/Settings/keybindingconfiguration.cpp
@@ -41,7 +41,7 @@ KeyBindingConfiguration::KeyBindingConfiguration(CfgKey *cfgKey, QSettings *sett
     ui->bindingTypeComboBox->addItem(i18nc("Do Nothing Action", "DoNothing"), "DoNothing");
     ui->bindingTypeComboBox->addItem(i18nc("Translate to Key Action", "TranslateToKey"), "TranslateToKey");
     ui->bindingTypeComboBox->addItem(i18nc("Run Command Action", "RunCommand"), "RunCommand");
-    qDebug() << "ConfigKey: " << cfgKey->cfgKeyEvents().first()->configKey();
+    kDebug() << "ConfigKey: " << cfgKey->cfgKeyEvents().first()->configKey();
     ui->bindingTypeComboBox->setCurrentIndex(ui->bindingTypeComboBox->findData(settings->value(cfgKey->cfgKeyEvents().first()->configKey(), "DoNothing")));
 }
 
@@ -62,7 +62,7 @@ void KeyBindingConfiguration::bindingChanged(int index)
     }
 
     if(configBindingKey == "DoNothing") return;
-    qDebug() << "configBindingKey: " << configBindingKey;
+    kDebug() << "configBindingKey: " << configBindingKey;
     SiblingsList *siblingsList = new SiblingsList(this);
     foreach(CfgKeyEvent* event, m_cfgKey->cfgKeyEvents()) {
         BindingConfigurationWidget *widget = widgetsFactories.value(configBindingKey)

--- a/Settings/keysconfigurationdialog.cpp
+++ b/Settings/keysconfigurationdialog.cpp
@@ -21,7 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "ui_keysconfigurationdialog.h"
 #include "backend/config/databaseentry.h"
 #include "domain/configevent.h"
-#include <QDebug>
+#include <KDebug>
 #include <QStringListModel>
 #include "models/cfgdevice.h"
 #include "keybindingconfiguration.h"
@@ -49,7 +49,7 @@ KeysConfigurationDialog::KeysConfigurationDialog(DeviceInfo *deviceInfo, const Q
     connect(ui->keys_listview, SIGNAL(doubleClicked(QModelIndex)), this, SLOT(cfgKeySelected(QModelIndex)));
 
     settings = new QSettings("GuLinux", qAppName(), this);
-    qDebug() << "avail groups: " << settings->childGroups();
+    kDebug() << "avail groups: " << settings->childGroups();
     settings->beginGroup(QString("bindings_%1").arg(profile));
 }
 
@@ -80,7 +80,7 @@ void KeysConfigurationDialog::accept()
 
 void KeysConfigurationDialog::keyEvent(const QString &keyName)
 {
-    qDebug() << "keyEvent: " << keyName;
+    kDebug() << "keyEvent: " << keyName;
     QModelIndex index = cfgKeyListModel->findKey(keyName);
     ui->keys_listview->selectionModel()->setCurrentIndex(index, QItemSelectionModel::ClearAndSelect);
     cfgKeySelected(index);

--- a/Settings/models/cfgdevice.h
+++ b/Settings/models/cfgdevice.h
@@ -22,7 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <QtCore/QObject>
 #include <QList>
-#include <QDebug>
+#include <KDebug>
 #include "cfgkey.h"
 #include "domain/deviceinfo.h"
 class DeviceInfo;

--- a/Settings/models/cfgkey.h
+++ b/Settings/models/cfgkey.h
@@ -21,7 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define CFGKEY_H
 
 #include <QtCore/QObject>
-#include <QDebug>
+#include <KDebug>
 #include <QList>
 #include "cfgkeyevent.h"
 #include <QAbstractListModel>

--- a/Settings/models/cfgkeyevent.h
+++ b/Settings/models/cfgkeyevent.h
@@ -21,7 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define CFGKEYEVENT_H
 
 #include <QtCore/QObject>
-#include <QDebug>
+#include <KDebug>
 #include <QAbstractListModel>
 class CfgKeyEvent;
 class CfgKey;


### PR DESCRIPTION
Now that Touche is a KDE only application I think it makes sense to use kDebug instead of qDebug.
Using kDebug makes it e.g. possible to control the debug output using kdebugdialog.
