### PR TITLE
fix for link failure, install kb databases in correct folder

### DIFF
--- a/App/CMakeLists.txt
+++ b/App/CMakeLists.txt
@@ -14,7 +14,7 @@ add_dependencies(${PROJECT_NAME} Touche_Core Touche_Configuration Touche_GUI)
 # TODO for /etc/udev it would be better to use variables, although this one is not going to change that easly...
 INSTALL(FILES files/99-hiddev-input.rules DESTINATION /etc/udev/rules.d)
 FILE(GLOB keyboardDatabases "files/KeyboardDatabases/*.json")
-INSTALL(FILES ${keyboardDatabases} DESTINATION share/apps/${PROJECT_NAME}/KeyboardDatabases/ )
+INSTALL(FILES ${keyboardDatabases} DESTINATION ${KDE4_DATA_INSTALL_DIR}/${PROJECT_NAME}/KeyboardDatabases/ )
 INSTALL(FILES desktop/Touche.desktop DESTINATION share/applications)
 INSTALL(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin)
 KDE4_INSTALL_ICONS( ${ICON_INSTALL_DIR} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ if(CWIID_FOUND)
     set(Touche_static_libraries ${Touche_static_libraries} ${CMAKE_BINARY_DIR}/lib/libWiimoteBridge.a )
 endif(CWIID_FOUND)
 
-set(Touche_libs ${Touche_libs} ${Touche_static_libraries} ${X11_LIBRARIES} ${QJSON_LIBRARIES} ${X11_XTest_LIB} ${KDE4_KDEUI_LIBS})
+set(Touche_libs ${Touche_static_libraries} ${Touche_libs} ${X11_LIBRARIES} ${QJSON_LIBRARIES} ${X11_XTest_LIB} ${KDE4_KDEUI_LIBS})
 include_directories( ${KDE4_INCLUDES} )
 
 


### PR DESCRIPTION
move static libraries to the beginning of Touche_libs, otherwise the link will fail when using the as-needed linker flag.

Also install keyboarddatabases in KDE4_DATA_INSTALL_DIR, as Touche searches for them there.
